### PR TITLE
Fix distutils error by adding setuptools dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dify_plugin~=0.4.4
 redis~=3.5.3
 redis-py-cluster~=2.1.3
+setuptools


### PR DESCRIPTION
Description:

Solves https://github.com/ztistic/dify-plugin-redis/issues/3

1. Problem Description

When running the plugin in a Python 3.12 environment, the application crashes with the following error:

ModuleNotFoundError: No module named 'distutils'



This occurs because the distutils module was officially removed in Python 3.12 (PEP 632), but the older version of the redis library used by this plugin still attempts to import it.

2. Solution

I have added setuptools to requirements.txt. The setuptools package provides the necessary distutils compatibility/shim, allowing the legacy redis library to function correctly in Python 3.12 without a full upgrade.

3. Error Log

<details>
<summary>
Click to expand full error log</summary>

[ERROR]plugin eft/redis:1.0.2 exited with error: exit status 1

File "/app/.../redis/connection.py", line 2, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'


</details>


---


1. 问题描述

在 Python 3.12 环境下运行该插件时，会出现 ModuleNotFoundError: No module named 'distutils' 错误。
这是因为 Python 3.12 正式移除了 distutils 标准库，而当前插件依赖的旧版本 redis 库仍然尝试引用该模块，从而导致崩溃。

2. 修改内容

我在 requirements.txt 中添加了 setuptools 依赖。
setuptools 提供了对 distutils 的兼容性支持（shim），使得旧版本的 redis 库可以在 Python 3.12 环境中正常运行，而无需强制升级 redis 版本。